### PR TITLE
Add transaction spreadsheet import feature

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="BigNumber" Version="1.1.1" />
     <PackageVersion Include="Bogus" Version="35.6.5" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="DustyTables" Version="4.0" />
@@ -23,6 +24,7 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="ShopifySharp" Version="6.25.4" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.9.0" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.0" />
     <PackageVersion Include="Testcontainers" Version="4.9.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.9.0" />

--- a/assets/capital-one-example-transactions.csv
+++ b/assets/capital-one-example-transactions.csv
@@ -1,0 +1,8 @@
+Account Number,Transaction Description,Transaction Date,Transaction Type,Transaction Amount,Balance
+1122,Debit Card Purchase - MERCHANT NAME 1165 TOWN MN,11/27/25,Debit,21,405.12
+1122,Withdrawal to My Savings XXXXXXX1234,11/26/25,Debit,175,426.12
+1122,Deposit from FOO B . BAZ PAY 123456,11/26/25,Credit,504.48,601.12
+1122,Digital Card Purchase - MCK HDWE MCKINLEY OH,11/25/25,Debit,23.52,96.64
+1122,Deposit from Nozzlegear Software XXXXXXX9876,11/25/25,Credit,300,120.16
+1122,Withdrawal from CITY OF MIDTOWN UTIL BILLS,11/25/25,Debit,271.73,-179.84
+1122,Withdrawal from APPLECARD GSBANK PAYMENT,11/24/25,Debit,50,91.89

--- a/foxy-balance.slnx
+++ b/foxy-balance.slnx
@@ -16,5 +16,6 @@
   <Folder Name="/tests/">
     <Project Path="tests/FoxyBalance.Database.Tests/FoxyBalance.Database.Tests.fsproj" />
     <Project Path="tests/FoxyBalance.Sync.Tests/FoxyBalance.Sync.Tests.fsproj" />
+    <Project Path="tests\FoxyBalance.Tests.Utils\FoxyBalance.Tests.Utils.fsproj" />
   </Folder>
 </Solution>

--- a/src/FoxyBalance.Database/Interfaces/ITransactionDatabase.fs
+++ b/src/FoxyBalance.Database/Interfaces/ITransactionDatabase.fs
@@ -7,6 +7,7 @@ type ITransactionDatabase =
     abstract member GetStatusAsync : userId: UserId * transactionId: TransactionId -> Task<TransactionStatus>
     abstract member GetAsync : userId: UserId * transactionId: TransactionId -> Task<Transaction option>
     abstract member ExistsAsync : userId: UserId * transactionId: TransactionId -> Task<bool>
+    abstract member BulkCreateAsync : userId: UserId * partialTransactions: PartialTransaction list -> Task<BulkCreationCount>
     abstract member CreateAsync : userId: UserId * partialTransaction: PartialTransaction -> Task<Transaction>
     abstract member UpdateAsync : userId: UserId * transactionId: TransactionId * partialTransaction: PartialTransaction -> Task<Transaction>
     abstract member ListAsync : userId: UserId * listOptions: ListOptions -> Task<Transaction seq>

--- a/src/FoxyBalance.Database/Models.fs
+++ b/src/FoxyBalance.Database/Models.fs
@@ -46,14 +46,17 @@ type Transaction =
       Amount : decimal
       DateCreated : DateTimeOffset
       Status : TransactionStatus
-      Type : TransactionType }
+      Type : TransactionType
+      ImportId : string option }
     
 type PartialTransaction =
     { Name : string
       DateCreated : DateTimeOffset
       Amount : decimal
       Status : TransactionStatus
-      Type : TransactionType }
+      Type : TransactionType
+      // A unique identifier assigned by a transaction parser which can identify this transaction in future imports.
+      ImportId : string option }
     
 type TransactionSum =
     { Sum : decimal

--- a/src/FoxyBalance.Database/Models.fs
+++ b/src/FoxyBalance.Database/Models.fs
@@ -9,6 +9,7 @@ type EmailAddress = string
 type UserId = int
 type TransactionId = int64
 type IncomeId = int64
+type BulkCreationCount = int
 
 type UserIdentifier =
     | Id of UserId

--- a/src/FoxyBalance.Migrations/FoxyBalance.Migrations.fsproj
+++ b/src/FoxyBalance.Migrations/FoxyBalance.Migrations.fsproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <Compile Include="Utils.fs" />
     <Compile Include="Migrations\Migration_001_InitialPostgreSQLSchema.fs" />
+    <Compile Include="Migrations\Migration_002_AddImportIdToTransactions.fs" />
     <Compile Include="Migrator.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FoxyBalance.Migrations/Migrations/Migration_002_AddImportIdToTransactions.fs
+++ b/src/FoxyBalance.Migrations/Migrations/Migration_002_AddImportIdToTransactions.fs
@@ -1,0 +1,18 @@
+namespace FoxyBalance.Migrations
+
+open FluentMigrator
+
+[<Migration(2L, "Add importid column to transactions table for tracking imported transactions")>]
+type Migration_002_AddImportIdToTransactions() =
+    inherit Migration()
+
+    override this.Up() =
+        this.Execute.Sql("""
+            ALTER TABLE foxybalance_transactions
+            ADD COLUMN importid VARCHAR(255);
+        """)
+
+    override this.Down() =
+        this.Execute.Sql("""
+            ALTER TABLE foxybalance_transactions DROP COLUMN importid;
+        """)

--- a/src/FoxyBalance.Server/Models.fs
+++ b/src/FoxyBalance.Server/Models.fs
@@ -356,3 +356,10 @@ module ViewModels =
     with
         static member Default =
             { Error = None }
+
+    type UploadTransactionsCompleteViewModel =
+        { NewTransactions: int
+          ExistingTransactions: int }
+    with
+        static member Default =
+            { NewTransactions = 0; ExistingTransactions = 0 }

--- a/src/FoxyBalance.Server/Models.fs
+++ b/src/FoxyBalance.Server/Models.fs
@@ -349,3 +349,9 @@ module ViewModels =
         { Error : string option
           Rate : int
           TaxYear : TaxYear }
+
+    type UploadTransactionsViewModel =
+        { Error: string option }
+    with
+        static member Default =
+            { Error = None }

--- a/src/FoxyBalance.Server/Models.fs
+++ b/src/FoxyBalance.Server/Models.fs
@@ -105,7 +105,8 @@ module RequestModels =
               Amount = 0.00M
               DateCreated = System.DateTimeOffset.Now
               Type = Debit
-              Status = Pending }
+              Status = Pending
+              ImportId = None }
             |> Result.Ok
             |> Result.bind validateName 
             |> Result.bind validateAmount

--- a/src/FoxyBalance.Server/Program.fs
+++ b/src/FoxyBalance.Server/Program.fs
@@ -18,6 +18,7 @@ open Microsoft.Extensions.Hosting
 open FoxyBalance.Sync
 open FoxyBalance.Sync.Models
 open Microsoft.Extensions.Configuration
+open Microsoft.Extensions.Hosting
 
 module Migrator = FoxyBalance.Migrations.Migrator
 
@@ -130,15 +131,18 @@ let main _ =
     let contentRoot = Directory.GetCurrentDirectory()
     let webRoot     = Path.Combine(contentRoot, "WebRoot")
     let host =
-        WebHost.CreateDefaultBuilder()
+        Host.CreateDefaultBuilder()
             .ConfigureAppConfiguration(fun hostingContext configuration ->
                 configuration.AddEnvironmentVariables(prefix = "FoxyBalance_") |> ignore
                 configuration.AddKeyPerFile("/run/secrets", optional = true) |> ignore
             )
-            .UseUrls([|"http://+:3000"|])
-            .UseWebRoot(webRoot)
-            .Configure(Action<IApplicationBuilder> configureApp)
-            .ConfigureServices(configureServices)
+            .ConfigureWebHostDefaults(fun webBuilder ->
+                webBuilder.UseUrls([|"http://+:3000"|]) |> ignore
+                webBuilder.UseWebRoot(webRoot) |> ignore
+                webBuilder.Configure(Action<IApplicationBuilder> configureApp) |> ignore
+                webBuilder.ConfigureServices(configureServices) |> ignore
+                webBuilder.ConfigureLogging(configureLogging) |> ignore
+            )
             .ConfigureLogging(configureLogging)
             .Build()
 

--- a/src/FoxyBalance.Server/Program.fs
+++ b/src/FoxyBalance.Server/Program.fs
@@ -40,6 +40,7 @@ let allRoutes : HttpHandler =
                 route "/balance/clear" >=> text "Not yet implemented"
                 route "/balance/adjust-balance" >=> text "Not yet implemented"
                 route "/balance/new" >=> Routes.Balance.newTransactionHandler
+                route "/balance/upload" >=> Routes.Balance.uploadTransactionsView
                 route "/balance" >=> Routes.Balance.homePageHandler
                 routef "/balance/%d" Routes.Balance.editTransactionHandler
 
@@ -56,6 +57,7 @@ let allRoutes : HttpHandler =
             route "/auth/register" >=> Routes.Auth.registerPostHandler
             authenticated [
                 route "/balance/new" >=> Routes.Balance.newTransactionPostHandler
+                route "/balance/upload" >=> Routes.Balance.uploadTransactionsHandler
                 routef "/balance/%d/delete" Routes.Balance.deleteTransactionPostHandler
                 routef "/balance/%d" Routes.Balance.existingTransactionPostHandler
                 route "/income/sync" >=> Routes.Income.executeSyncHandler

--- a/src/FoxyBalance.Server/Program.fs
+++ b/src/FoxyBalance.Server/Program.fs
@@ -122,7 +122,7 @@ let configureServices (app : WebHostBuilderContext) (services : IServiceCollecti
     services.Configure<ShopifyPartnerClientOptions>(app.Configuration.GetSection "Shopify") |> ignore
 
 let configureLogging (builder : ILoggingBuilder) =
-    builder.AddFilter(fun l -> l.Equals LogLevel.Error)
+    builder.AddFilter(fun l -> l >= LogLevel.Information)
            .AddConsole()
            .AddDebug() |> ignore
 

--- a/src/FoxyBalance.Server/Routes/Balance.fs
+++ b/src/FoxyBalance.Server/Routes/Balance.fs
@@ -1,11 +1,14 @@
 ﻿namespace FoxyBalance.Server.Routes
 
 open FoxyBalance.Database.Interfaces
+open FoxyBalance.Sync
 open Giraffe
 open FoxyBalance.Server
 open FoxyBalance.Database.Models
 open FoxyBalance.Server.Models.RequestModels
 open FoxyBalance.Server.Models.ViewModels
+open Microsoft.Extensions.DependencyInjection
+
 module Views = FoxyBalance.Server.Views.Balance
 
 module Balance =
@@ -114,4 +117,12 @@ module Balance =
         |> createOrEditTransaction
 
     let deleteTransactionPostHandler (transactionId : int64) : HttpHandler =
-        deleteTransaction transactionId 
+        deleteTransaction transactionId
+
+    let uploadTransactionsView : HttpHandler =
+        UploadTransactionsViewModel.Default
+        |> Views.Balance.uploadTransactionsPage
+        |> htmlView
+
+    let uploadTransactionsHandler : HttpHandler =
+        failwith "not implemented"

--- a/src/FoxyBalance.Server/Views/Balance.fs
+++ b/src/FoxyBalance.Server/Views/Balance.fs
@@ -153,14 +153,14 @@ module Balance =
                         {| Value = "credit"; Label = "Credit/Deposit"; Selected = model.Type = "credit" |}
                     ]
                 ]
-                
+
                 Form.Element.TextInput [
                     Form.Placeholder "Supermarket purchase"
                     Form.LabelText "Name or description"
                     Form.HtmlName "name"
                     Form.Required
                     Form.Value model.Name ]
-                
+
                 // Group the amount and check number inputs together
                 Form.Element.Group [
                     Form.Element.NumberInput [
@@ -172,14 +172,14 @@ module Balance =
                         Form.Step 0.01M
                         Form.Required
                         Form.Value model.Amount ]
-                    
+
                     Form.Element.TextInput [
                         Form.Placeholder "1234"
                         Form.LabelText "Check Number (optional)"
                         Form.HtmlName "checkNumber"
                         Form.Value model.CheckNumber ]
                 ]
-                
+
                 // Group the date inputs together
                 Form.Element.Group [
                     Form.Element.DateInput [
@@ -188,25 +188,68 @@ module Balance =
                         Form.Value date
                         Form.HtmlName "date"
                         Form.Required ]
-                    
+
                     Form.Element.DateInput [
                         Form.Placeholder placeholderDate
                         Form.LabelText "Date Cleared (optional)"
                         Form.Value model.ClearDate
                         Form.HtmlName "clearDate" ]
                 ]
-                
+
                 Form.Element.MaybeError model.Error
-                
+
                 // Group the buttons together
                 Form.Element.Group [
                     deleteButton
                     // Use an empty div so we still have two columns
                     |> Option.defaultValue Form.Element.EmptyDiv
-                    
+
                     Form.Element.Button [
                         Form.ButtonText buttonText
-                        Form.Alignment Form.ButtonAlignment.Right 
+                        Form.Alignment Form.ButtonAlignment.Right
+                        Form.Color Form.ButtonColor.Success
+                        Form.Type Form.Submit ]
+                ]
+            ]
+        ]
+
+    let uploadTransactionsPage (model : UploadTransactionsViewModel) =
+        let title = "Upload transactions"
+
+        Shared.pageContainer title Shared.Authenticated Shared.WrappedInSection [
+            Shared.level [
+                Shared.LeftLevel [
+                    Shared.LevelItem.Element (Shared.title title)
+                ]
+                Shared.RightLevel [
+                     G.a [A._href "/balance"; A._class "button"] [
+                        G.str "Cancel" ]
+                     |> Shared.LevelItem.Element
+                ]
+            ]
+            Form.create [Form.Method Form.Post; Form.AutoComplete false; Form.EncType Form.Multipart] [
+                Form.Element.SelectBox [
+                    Form.SelectOption.LabelText "Source"
+                    Form.SelectOption.HtmlName "source"
+                    Form.SelectOption.Options [ {| Label = "Capital One"; Value = "capital-one"; Selected = true |} ]
+                    Form.SelectOption.Value "capital-one" ]
+
+                Form.Element.FileInput [
+                    Form.LabelText "CSV file"
+                    Form.HelpText "Upload a CSV file containing your transactions here. The transactions will be parsed according to the source, and the individual transaction records will be applied to your balance."
+                    Form.Accept ".csv"
+                    Form.HtmlName "transactionsCsvFile" ]
+
+                Form.Element.MaybeError model.Error
+
+                // Group the buttons together
+                Form.Element.Group [
+                    // Use an empty div so we still have two columns
+                    Form.Element.EmptyDiv
+
+                    Form.Element.Button [
+                        Form.ButtonText "Upload"
+                        Form.Alignment Form.ButtonAlignment.Right
                         Form.Color Form.ButtonColor.Success
                         Form.Type Form.Submit ]
                 ]

--- a/src/FoxyBalance.Server/Views/Balance.fs
+++ b/src/FoxyBalance.Server/Views/Balance.fs
@@ -71,7 +71,7 @@ module Balance =
                 Shared.LeftLevel statusControls
                 Shared.RightLevel [
                     Shared.LevelItem.Element (a [_href "/balance/clear"; _class "button is-light"] [str "Clear All"])
-                    Shared.LevelItem.Element (a [_href "/balance/adjust-balance"; _class "button is-light"] [str "Adjust Balance"])
+                    Shared.LevelItem.Element (a [_href "/balance/upload"; _class "button is-info"] [str "Upload Transactions"])
                     Shared.LevelItem.Element (a [_href "/balance/new"; _class "button is-success"] [str "New Transaction"])
                 ]
             ]
@@ -253,5 +253,28 @@ module Balance =
                         Form.Color Form.ButtonColor.Success
                         Form.Type Form.Submit ]
                 ]
+            ]
+        ]
+
+    let uploadTransactionsCompletePage (model: UploadTransactionsCompleteViewModel) =
+        let title = "Transaction upload complete"
+
+        Shared.pageContainer title Shared.Authenticated Shared.WrappedInSection [
+            Shared.level [
+                Shared.LeftLevel [
+                    Shared.LevelItem.Element (Shared.title title)
+                ]
+                Shared.RightLevel [
+                     G.a [A._href "/balance"; A._class "button is-info"] [
+                        G.str "Transactions" ]
+                     |> Shared.LevelItem.Element
+                ]
+            ]
+            // Totals
+            Shared.evenlySpacedLevel [
+                // TODO: add help text explaining what "Existed" means
+                Shared.LevelItem.HeadingAndTitle ("Created", string model.NewTransactions)
+                Shared.LevelItem.HeadingAndTitle ("Existed", string model.ExistingTransactions)
+                Shared.LevelItem.HeadingAndTitle ("Total", string (model.ExistingTransactions + model.NewTransactions))
             ]
         ]

--- a/src/FoxyBalance.Server/Views/Shared.fs
+++ b/src/FoxyBalance.Server/Views/Shared.fs
@@ -320,7 +320,7 @@ module Shared =
                     else
                         let queryParams =
                             options.ExtraQueryArgs
-                            |> Map.add "page" (box options.CurrentPage)
+                            |> Map.add "page" (box page)
                             |> toQueryString
                         [ _class "pagination-link"
                           _href $"/{route}?{queryParams}"

--- a/src/FoxyBalance.Server/appsettings.json
+++ b/src/FoxyBalance.Server/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "System": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "FoxyBalance": "Information"
+    }
+  }
+}

--- a/src/FoxyBalance.Sync/CapitalOneTransactionParser.fs
+++ b/src/FoxyBalance.Sync/CapitalOneTransactionParser.fs
@@ -1,0 +1,61 @@
+namespace FoxyBalance.Sync
+
+open System
+open System.IO
+open System.IO.Hashing
+open System.Runtime.CompilerServices
+open System.Text
+open BigNumber
+open FSharp.Data
+open FoxyBalance.Sync.Models
+
+type CapitalOneTransactions = CsvProvider<"../../assets/capital-one-example-transactions.csv", Schema = "Transaction Date=string">
+
+type CapitalOneTransactionParser() =
+    let mkTransactionId (row: CapitalOneTransactions.Row): string =
+        let identifier =
+            row.``Transaction Date``
+            + "_" + string row.``Account Number``
+            + "_" + row.``Transaction Type``
+            + "_" + row.``Transaction Description``
+            + "_" + string row.``Transaction Amount``
+            + "_" + string row.Balance
+
+        Encoding.UTF8.GetBytes identifier
+        |> Crc32.Hash
+        |> Base36Number
+        |> _.ToString()
+
+    let parseTransactionDate (transactionDate: string): DateTimeOffset =
+        let date = DateOnly.ParseExact(transactionDate, "MM/dd/yy")
+        // Since Capital One does not record time information, assume the dates are recorded in UTC
+        let offset = TimeSpan.Zero
+        DateTimeOffset(date, TimeOnly(0), offset = offset)
+
+    let parseTransactionType (transactionType: string): CapitalOneTransactionType =
+        if transactionType.Equals("debit", StringComparison.OrdinalIgnoreCase) then
+            CapitalOneTransactionType.Debit
+        elif transactionType.Equals("credit", StringComparison.OrdinalIgnoreCase) then
+            CapitalOneTransactionType.Credit
+        else
+            raise (SwitchExpressionException transactionType)
+
+    let mapTransactions (csv : CapitalOneTransactions): CapitalOneTransaction list =
+        csv.Rows
+        |> Seq.map (fun row ->
+            { Id = mkTransactionId row
+              DateCreated = parseTransactionDate row.``Transaction Date``
+              AccountNumber = string row.``Account Number``
+              Description = row.``Transaction Description``
+              Type = parseTransactionType row.``Transaction Type``
+              Amount = row.``Transaction Amount``
+              Balance =  row.Balance })
+        |> List.ofSeq
+
+    member _.FromCsv (fileText: string) =
+        CapitalOneTransactions.Parse fileText
+        |> mapTransactions
+
+    member _.FromCsvStream (stream: Stream) =
+        CapitalOneTransactions.Load stream
+        |> mapTransactions

--- a/src/FoxyBalance.Sync/FoxyBalance.Sync.fsproj
+++ b/src/FoxyBalance.Sync/FoxyBalance.Sync.fsproj
@@ -11,12 +11,15 @@
     <Compile Include="GumroadClient.fs" />
     <Compile Include="ShopifyPartnerClient.fs" />
     <Compile Include="PaypalTransactionParser.fs" />
+    <Compile Include="CapitalOneTransactionParser.fs" />
     <Compile Include="ServiceCollectionExtensions.fs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="BigNumber" />
     <PackageReference Include="FSharp.Core" />
     <PackageReference Include="FSharp.Data" />
     <PackageReference Include="ShopifySharp" />
     <PackageReference Include="JsonSharp" />
+    <PackageReference Include="System.IO.Hashing" />
   </ItemGroup>
 </Project>

--- a/src/FoxyBalance.Sync/Models.fs
+++ b/src/FoxyBalance.Sync/Models.fs
@@ -75,3 +75,18 @@ type ShopifyTransactionListResult = {
     PreviousPageCursor: string option
     Transactions: ShopifyTransaction seq
 }
+
+[<RequireQualifiedAccess>]
+type CapitalOneTransactionType =
+    | Credit
+    | Debit
+
+type CapitalOneTransaction = {
+    Id: string
+    DateCreated: DateTimeOffset
+    AccountNumber: string
+    Description: string
+    Type: CapitalOneTransactionType
+    Amount: decimal
+    Balance: decimal
+}

--- a/src/FoxyBalance.Sync/ServiceCollectionExtensions.fs
+++ b/src/FoxyBalance.Sync/ServiceCollectionExtensions.fs
@@ -11,6 +11,7 @@ module ServiceCollectionExtensions =
         member services.AddFoxyBalanceSyncClients() =
             %services.AddSingleton<GumroadClient>()
             %services.AddSingleton<PaypalTransactionParser>()
+            %services.AddSingleton<CapitalOneTransactionParser>()
             %services.AddSingleton<ShopifyPartnerClient>()
             %services.AddSingleton<IRequestExecutionPolicy, PartnerServiceRetryExecutionPolicy>()
             %services.AddHttpClient()

--- a/tests/FoxyBalance.Database.Tests/FoxyBalance.Database.Tests.fsproj
+++ b/tests/FoxyBalance.Database.Tests/FoxyBalance.Database.Tests.fsproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\FoxyBalance.Database\FoxyBalance.Database.fsproj" />
     <ProjectReference Include="..\..\src\FoxyBalance.Migrator\FoxyBalance.Migrator.fsproj" />
+    <ProjectReference Include="..\FoxyBalance.Tests.Utils\FoxyBalance.Tests.Utils.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/FoxyBalance.Database.Tests/TransactionDatabaseTests.fs
+++ b/tests/FoxyBalance.Database.Tests/TransactionDatabaseTests.fs
@@ -603,3 +603,523 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
             %result.PendingSum.Should().Be(0M)
             %result.Sum.Should().Be(0M)
         }
+
+    [<Fact>]
+    member _.``BulkCreateAsync should return 0 when given an empty list``() =
+        task {
+            // Setup
+            let! user = createUser ()
+            let emptyList: PartialTransaction list = []
+
+            // Act
+            let! result = database.BulkCreateAsync(user.Id, emptyList)
+
+            // Assert
+            %result.Should().Be(0)
+        }
+
+    [<Fact>]
+    member _.``BulkCreateAsync should create multiple transactions``() =
+        task {
+            // Setup
+            let! user = createUser ()
+            let transactions = [1..10] |> List.map (fun i ->
+                { Name = $"Bulk Transaction {i}"
+                  Amount = decimal i * 10M
+                  DateCreated = bogus.Date.RecentOffset 20
+                  Status = if i % 2 = 0 then Cleared (bogus.Date.RecentOffset 5) else Pending
+                  Type = if i % 3 = 0 then Credit else Debit
+                  ImportId = None })
+
+            // Act
+            let! rowsCreated = database.BulkCreateAsync(user.Id, transactions)
+
+            // Assert
+            %rowsCreated.Should().Be(10)
+
+            // Verify all transactions were created
+            let! allTransactions = database.ListAsync(user.Id, { Limit = 100; Offset = 0; Order = Ascending; Status = AllTransactions })
+            %allTransactions.Should().HaveLength(10)
+        }
+
+    [<Theory>]
+    [<CombinatorialData>]
+    member _.``BulkCreateAsync should handle all transaction types``(transactionType: TestTransactionType) =
+        task {
+            // Setup
+            let! user = createUser ()
+            let transactionType =
+                match transactionType with
+                | TestTransactionType.Check -> Check { CheckNumber = bogus.Random.Number(1000, 9999).ToString("D4") }
+                | TestTransactionType.NonRecurringBill -> Bill { Recurring = false }
+                | TestTransactionType.RecurringBill -> Bill { Recurring = true }
+                | TestTransactionType.Credit -> Credit
+                | TestTransactionType.Debit -> Debit
+                | _ -> raise (SwitchExpressionException transactionType)
+
+            let transactions = [1..5] |> List.map (fun i ->
+                { Name = $"Bulk {transactionType} {i}"
+                  Amount = decimal i * 5M
+                  DateCreated = bogus.Date.RecentOffset 20
+                  Status = Pending
+                  Type = transactionType
+                  ImportId = None })
+
+            // Act
+            let! rowsCreated = database.BulkCreateAsync(user.Id, transactions)
+
+            // Assert
+            %rowsCreated.Should().Be(5)
+
+            let! allTransactions = database.ListAsync(user.Id, { Limit = 100; Offset = 0; Order = Ascending; Status = AllTransactions })
+            %allTransactions.Should().HaveLength(5)
+            %allTransactions.Should().AllSatisfy(fun t -> t.Type.Should().Be(transactionType))
+        }
+
+    [<Theory>]
+    [<CombinatorialData>]
+    member _.``BulkCreateAsync should handle both Pending and Cleared statuses``(isCleared: bool) =
+        task {
+            // Setup
+            let! user = createUser ()
+            let clearedDate = bogus.Date.RecentOffset 10
+            let status = if isCleared then Cleared clearedDate else Pending
+
+            let transactions = [1..3] |> List.map (fun i ->
+                { Name = $"Transaction {i}"
+                  Amount = decimal i * 20M
+                  DateCreated = bogus.Date.RecentOffset 20
+                  Status = status
+                  Type = Debit
+                  ImportId = None })
+
+            // Act
+            let! rowsCreated = database.BulkCreateAsync(user.Id, transactions)
+
+            // Assert
+            %rowsCreated.Should().Be(3)
+
+            let! allTransactions = database.ListAsync(user.Id, { Limit = 100; Offset = 0; Order = Ascending; Status = AllTransactions })
+            %allTransactions.Should().HaveLength(3)
+
+            for transaction in allTransactions do
+                match (transaction.Status, isCleared) with
+                | Pending, false -> () // Expected
+                | Cleared actualDate, true ->
+                    %actualDate.Should().BeCloseTo(clearedDate, TimeSpan.FromSeconds 1L)
+                | _ -> failwith "Unexpected status combination"
+        }
+
+    [<Fact>]
+    member _.``BulkCreateAsync should create transactions with mixed types and statuses``() =
+        task {
+            // Setup
+            let! user = createUser ()
+            let transactions = [
+                { Name = "Check Transaction"
+                  Amount = 100M
+                  DateCreated = bogus.Date.RecentOffset 20
+                  Status = Pending
+                  Type = Check { CheckNumber = "1234" }
+                  ImportId = None }
+                { Name = "Recurring Bill"
+                  Amount = 50M
+                  DateCreated = bogus.Date.RecentOffset 19
+                  Status = Cleared (bogus.Date.RecentOffset 5)
+                  Type = Bill { Recurring = true }
+                  ImportId = None }
+                { Name = "Non-Recurring Bill"
+                  Amount = 75M
+                  DateCreated = bogus.Date.RecentOffset 18
+                  Status = Pending
+                  Type = Bill { Recurring = false }
+                  ImportId = None }
+                { Name = "Debit Transaction"
+                  Amount = 25M
+                  DateCreated = bogus.Date.RecentOffset 17
+                  Status = Cleared (bogus.Date.RecentOffset 3)
+                  Type = Debit
+                  ImportId = None }
+                { Name = "Credit Transaction"
+                  Amount = 200M
+                  DateCreated = bogus.Date.RecentOffset 16
+                  Status = Pending
+                  Type = Credit
+                  ImportId = None }
+            ]
+
+            // Act
+            let! rowsCreated = database.BulkCreateAsync(user.Id, transactions)
+
+            // Assert
+            %rowsCreated.Should().Be(5)
+
+            let! allTransactions = database.ListAsync(user.Id, { Limit = 100; Offset = 0; Order = Ascending; Status = AllTransactions })
+            %allTransactions.Should().HaveLength(5)
+
+            // Verify we have all the different types
+            let hasCheck = allTransactions |> Seq.exists (fun t -> match t.Type with Check _ -> true | _ -> false)
+            let hasBill = allTransactions |> Seq.exists (fun t -> match t.Type with Bill _ -> true | _ -> false)
+            let hasDebit = allTransactions |> Seq.exists (fun t -> match t.Type with Debit -> true | _ -> false)
+            let hasCredit = allTransactions |> Seq.exists (fun t -> match t.Type with Credit -> true | _ -> false)
+
+            %hasCheck.Should().BeTrue()
+            %hasBill.Should().BeTrue()
+            %hasDebit.Should().BeTrue()
+            %hasCredit.Should().BeTrue()
+        }
+
+    [<Fact>]
+    member _.``BulkCreateAsync should fail if the user does not exist``() =
+        task {
+            // Setup
+            let transactions = [
+                { Name = "Transaction 1"
+                  Amount = 100M
+                  DateCreated = bogus.Date.RecentOffset 20
+                  Status = Pending
+                  Type = Debit
+                  ImportId = None }
+            ]
+            let userId = -1
+
+            // Act
+            let act () =
+                database.BulkCreateAsync(userId, transactions)
+                |> Async.AwaitTask
+                |> Async.RunSynchronously
+
+            // Assert
+            %act.Should().ThrowInner<PostgresException, _>()
+                 .Whose
+                 .Message.Should().Contain("violates foreign key constraint")
+        }
+
+    [<Fact>]
+    member _.``BulkCreateAsync should handle ImportId when provided``() =
+        task {
+            // Setup
+            let! user = createUser ()
+            let baseDate = DateTimeOffset.UtcNow.AddDays(-20.0)
+            let transactions = [
+                { Name = "Imported Transaction 1"
+                  Amount = 100M
+                  DateCreated = baseDate
+                  Status = Pending
+                  Type = Debit
+                  ImportId = Some "import-123" }
+                { Name = "Imported Transaction 2"
+                  Amount = 200M
+                  DateCreated = baseDate.AddDays(1.0)
+                  Status = Cleared (bogus.Date.RecentOffset 5)
+                  Type = Credit
+                  ImportId = Some "import-456" }
+            ]
+
+            // Act
+            let! rowsCreated = database.BulkCreateAsync(user.Id, transactions)
+
+            // Assert
+            %rowsCreated.Should().Be(2)
+
+            let! allTransactions = database.ListAsync(user.Id, { Limit = 100; Offset = 0; Order = Ascending; Status = AllTransactions })
+            %allTransactions.Should().HaveLength(2)
+
+            let transactionsList = allTransactions |> Seq.toList
+            %transactionsList[0].ImportId.Should().Be(Some "import-123")
+            %transactionsList[1].ImportId.Should().Be(Some "import-456")
+        }
+
+    [<Fact>]
+    member _.``BulkCreateAsync should handle missing ImportId``() =
+        task {
+            // Setup
+            let! user = createUser ()
+            let transactions = [
+                { Name = "Transaction without ImportId"
+                  Amount = 50M
+                  DateCreated = bogus.Date.RecentOffset 20
+                  Status = Pending
+                  Type = Debit
+                  ImportId = None }
+            ]
+
+            // Act
+            let! rowsCreated = database.BulkCreateAsync(user.Id, transactions)
+
+            // Assert
+            %rowsCreated.Should().Be(1)
+
+            let! allTransactions = database.ListAsync(user.Id, { Limit = 100; Offset = 0; Order = Ascending; Status = AllTransactions })
+            %allTransactions.Should().HaveLength(1)
+
+            let transaction = allTransactions |> Seq.head
+            %transaction.ImportId.Should().Be(None)
+        }
+
+    [<Fact>]
+    member _.``BulkCreateAsync should handle mixed ImportId scenarios``() =
+        task {
+            // Setup
+            let! user = createUser ()
+            let transactions = [
+                { Name = "With ImportId"
+                  Amount = 100M
+                  DateCreated = bogus.Date.RecentOffset 20
+                  Status = Pending
+                  Type = Debit
+                  ImportId = Some "import-789" }
+                { Name = "Without ImportId"
+                  Amount = 50M
+                  DateCreated = bogus.Date.RecentOffset 19
+                  Status = Pending
+                  Type = Credit
+                  ImportId = None }
+            ]
+
+            // Act
+            let! rowsCreated = database.BulkCreateAsync(user.Id, transactions)
+
+            // Assert
+            %rowsCreated.Should().Be(2)
+
+            let! allTransactions = database.ListAsync(user.Id, { Limit = 100; Offset = 0; Order = Ascending; Status = AllTransactions })
+            let transactionsList = allTransactions |> Seq.toList
+
+            %transactionsList.Should().HaveLength(2)
+            %transactionsList.Should().SatisfyExactlyOneThat(_.ImportId.Should().Be(Some "import-789"))
+            %transactionsList.Should().SatisfyExactlyOneThat(_.ImportId.Should().Be(None))
+        }
+
+    [<Fact>]
+    member _.``CreateAsync should handle ImportId when provided``() =
+        task {
+            // Setup
+            let! user = createUser ()
+            let partialTransaction: PartialTransaction =
+                { Name = "Transaction with ImportId"
+                  Amount = 150M
+                  DateCreated = bogus.Date.RecentOffset 20
+                  Status = Pending
+                  Type = Debit
+                  ImportId = Some "create-import-123" }
+
+            // Act
+            let! result = database.CreateAsync(user.Id, partialTransaction)
+
+            // Assert
+            %result.ImportId.Should().Be(Some "create-import-123")
+
+            // Verify it was persisted
+            let! retrieved = database.GetAsync(user.Id, result.Id)
+            %retrieved.Should().BeSome()
+            %retrieved.Value.ImportId.Should().Be(Some "create-import-123")
+        }
+
+    [<Fact>]
+    member _.``CreateAsync should handle missing ImportId``() =
+        task {
+            // Setup
+            let! user = createUser ()
+            let partialTransaction: PartialTransaction =
+                { Name = "Transaction without ImportId"
+                  Amount = 75M
+                  DateCreated = bogus.Date.RecentOffset 20
+                  Status = Pending
+                  Type = Credit
+                  ImportId = None }
+
+            // Act
+            let! result = database.CreateAsync(user.Id, partialTransaction)
+
+            // Assert
+            %result.ImportId.Should().Be(None)
+
+            // Verify it was persisted
+            let! retrieved = database.GetAsync(user.Id, result.Id)
+            %retrieved.Should().BeSome()
+            %retrieved.Value.ImportId.Should().Be(None)
+        }
+
+    [<Fact>]
+    member _.``UpdateAsync should preserve ImportId``() =
+        task {
+            // Setup
+            let! user = createUser ()
+            let originalTransaction: PartialTransaction =
+                { Name = "Original Transaction"
+                  Amount = 100M
+                  DateCreated = bogus.Date.RecentOffset 20
+                  Status = Pending
+                  Type = Debit
+                  ImportId = Some "update-import-123" }
+
+            let! created = database.CreateAsync(user.Id, originalTransaction)
+
+            let updatedTransaction: PartialTransaction =
+                { Name = "Updated Transaction"
+                  Amount = 200M
+                  DateCreated = bogus.Date.RecentOffset 5
+                  Status = Cleared (bogus.Date.RecentOffset 2)
+                  Type = Credit
+                  ImportId = Some "update-import-123" }
+
+            // Act
+            let! result = database.UpdateAsync(user.Id, created.Id, updatedTransaction)
+
+            // Assert
+            %result.ImportId.Should().Be(Some "update-import-123")
+            %result.Name.Should().Be("Updated Transaction")
+        }
+
+    [<Fact>]
+    member _.``BulkCreateAsync should skip transactions with duplicate ImportId``() =
+        task {
+            // Setup
+            let! user = createUser ()
+
+            // First, create some transactions with ImportIds
+            let initialTransactions = [
+                { Name = "Existing Transaction 1"
+                  Amount = 100M
+                  DateCreated = bogus.Date.RecentOffset 20
+                  Status = Pending
+                  Type = Debit
+                  ImportId = Some "import-duplicate-1" }
+                { Name = "Existing Transaction 2"
+                  Amount = 200M
+                  DateCreated = bogus.Date.RecentOffset 19
+                  Status = Cleared (bogus.Date.RecentOffset 5)
+                  Type = Credit
+                  ImportId = Some "import-duplicate-2" }
+            ]
+
+            let! initialRowsCreated = database.BulkCreateAsync(user.Id, initialTransactions)
+            %initialRowsCreated.Should().Be(2)
+
+            // Now try to import again with some duplicates and some new transactions
+            let duplicateTransactions = [
+                { Name = "Duplicate Transaction 1"  // Should be skipped
+                  Amount = 150M
+                  DateCreated = bogus.Date.RecentOffset 18
+                  Status = Pending
+                  Type = Debit
+                  ImportId = Some "import-duplicate-1" }
+                { Name = "New Transaction"  // Should be imported
+                  Amount = 300M
+                  DateCreated = bogus.Date.RecentOffset 17
+                  Status = Pending
+                  Type = Credit
+                  ImportId = Some "import-new-1" }
+                { Name = "Duplicate Transaction 2"  // Should be skipped
+                  Amount = 250M
+                  DateCreated = bogus.Date.RecentOffset 16
+                  Status = Pending
+                  Type = Debit
+                  ImportId = Some "import-duplicate-2" }
+                { Name = "Another New Transaction"  // Should be imported
+                  Amount = 400M
+                  DateCreated = bogus.Date.RecentOffset 15
+                  Status = Pending
+                  Type = Credit
+                  ImportId = Some "import-new-2" }
+            ]
+
+            // Act
+            let! secondRowsCreated = database.BulkCreateAsync(user.Id, duplicateTransactions)
+
+            // Assert
+            %secondRowsCreated.Should().Be(2)  // Only 2 new transactions should be created
+
+            let! allTransactions = database.ListAsync(user.Id, { Limit = 100; Offset = 0; Order = Ascending; Status = AllTransactions })
+            %allTransactions.Should().HaveLength(4)  // 2 original + 2 new
+
+            // Verify the original transactions were not duplicated
+            let transactionsList = allTransactions |> Seq.toList
+            let transaction1 = transactionsList |> List.find (fun t -> t.ImportId = Some "import-duplicate-1")
+            let transaction2 = transactionsList |> List.find (fun t -> t.ImportId = Some "import-duplicate-2")
+
+            %transaction1.Name.Should().Be("Existing Transaction 1")
+            %transaction1.Amount.Should().Be(100M)
+            %transaction2.Name.Should().Be("Existing Transaction 2")
+            %transaction2.Amount.Should().Be(200M)
+        }
+
+    [<Fact>]
+    member _.``BulkCreateAsync should not skip transactions without ImportId``() =
+        task {
+            // Setup
+            let! user = createUser ()
+
+            let transactions = [
+                { Name = "Transaction 1"
+                  Amount = 100M
+                  DateCreated = bogus.Date.RecentOffset 20
+                  Status = Pending
+                  Type = Debit
+                  ImportId = None }
+                { Name = "Transaction 2"
+                  Amount = 200M
+                  DateCreated = bogus.Date.RecentOffset 19
+                  Status = Pending
+                  Type = Debit
+                  ImportId = None }
+            ]
+
+            // Act - Import the same transactions twice
+            let! firstImport = database.BulkCreateAsync(user.Id, transactions)
+            let! secondImport = database.BulkCreateAsync(user.Id, transactions)
+
+            // Assert - All transactions should be imported since they don't have ImportId
+            %firstImport.Should().Be(2)
+            %secondImport.Should().Be(2)
+
+            let! allTransactions = database.ListAsync(user.Id, { Limit = 100; Offset = 0; Order = Ascending; Status = AllTransactions })
+            %allTransactions.Should().HaveLength(4)  // Both imports should create transactions
+        }
+
+    [<Fact>]
+    member _.``BulkCreateAsync should only check ImportId for the specific user``() =
+        task {
+            // Setup
+            let! user1 = createUser ()
+            let! user2 = createUser ()
+
+            let transaction1 = [
+                { Name = "User 1 Transaction"
+                  Amount = 100M
+                  DateCreated = bogus.Date.RecentOffset 20
+                  Status = Pending
+                  Type = Debit
+                  ImportId = Some "shared-import-id" }
+            ]
+
+            let transaction2 = [
+                { Name = "User 2 Transaction"
+                  Amount = 200M
+                  DateCreated = bogus.Date.RecentOffset 19
+                  Status = Pending
+                  Type = Credit
+                  ImportId = Some "shared-import-id" }
+            ]
+
+            // Act - Both users import transactions with the same ImportId
+            let! user1Rows = database.BulkCreateAsync(user1.Id, transaction1)
+            let! user2Rows = database.BulkCreateAsync(user2.Id, transaction2)
+
+            // Assert - Both should succeed because ImportId uniqueness is scoped to the user
+            %user1Rows.Should().Be(1)
+            %user2Rows.Should().Be(1)
+
+            let! user1Transactions = database.ListAsync(user1.Id, { Limit = 100; Offset = 0; Order = Ascending; Status = AllTransactions })
+            let! user2Transactions = database.ListAsync(user2.Id, { Limit = 100; Offset = 0; Order = Ascending; Status = AllTransactions })
+
+            %user1Transactions.Should().HaveLength(1)
+            %user2Transactions.Should().HaveLength(1)
+
+            let user1Transaction = user1Transactions |> Seq.head
+            let user2Transaction = user2Transactions |> Seq.head
+
+            %user1Transaction.Name.Should().Be("User 1 Transaction")
+            %user2Transaction.Name.Should().Be("User 2 Transaction")
+        }

--- a/tests/FoxyBalance.Database.Tests/TransactionDatabaseTests.fs
+++ b/tests/FoxyBalance.Database.Tests/TransactionDatabaseTests.fs
@@ -52,7 +52,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                   Amount = bogus.Finance.Amount()
                   DateCreated = bogus.Date.RecentOffset 20
                   Status = status
-                  Type = transactionType  }
+                  Type = transactionType
+                  ImportId = None }
 
             // Act
             let! result = database.CreateAsync(user.Id, partialTransaction)
@@ -75,7 +76,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                   Amount = bogus.Finance.Amount()
                   DateCreated = bogus.Date.RecentOffset 20
                   Status = Pending
-                  Type = TransactionType.Debit }
+                  Type = TransactionType.Debit
+                  ImportId = None }
             let userId = -1
 
             // Act
@@ -107,7 +109,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                   Amount = bogus.Finance.Amount()
                   DateCreated = bogus.Date.RecentOffset 20
                   Status = status
-                  Type = TransactionType.Debit }
+                  Type = TransactionType.Debit
+                  ImportId = None }
 
             let! created = database.CreateAsync(user.Id, partialTransaction)
 
@@ -131,7 +134,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                   Amount = bogus.Finance.Amount()
                   DateCreated = bogus.Date.RecentOffset 20
                   Status = Pending
-                  Type = TransactionType.Debit }
+                  Type = TransactionType.Debit
+                  ImportId = None }
 
             let! created = database.CreateAsync(user.Id, partialTransaction)
 
@@ -173,7 +177,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                   Amount = bogus.Finance.Amount()
                   DateCreated = bogus.Date.RecentOffset 20
                   Status = Pending
-                  Type = TransactionType.Debit }
+                  Type = TransactionType.Debit
+                  ImportId = None }
 
             let! created = database.CreateAsync(user1.Id, partialTransaction)
 
@@ -194,7 +199,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                   Amount = bogus.Finance.Amount()
                   DateCreated = bogus.Date.RecentOffset 20
                   Status = Pending
-                  Type = TransactionType.Debit }
+                  Type = TransactionType.Debit
+                  ImportId = None }
 
             let! created = database.CreateAsync(user.Id, partialTransaction)
 
@@ -230,7 +236,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                   Amount = bogus.Finance.Amount()
                   DateCreated = bogus.Date.RecentOffset 20
                   Status = Pending
-                  Type = TransactionType.Debit }
+                  Type = TransactionType.Debit
+                  ImportId = None }
 
             let! created = database.CreateAsync(user1.Id, partialTransaction)
 
@@ -251,7 +258,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                   Amount = bogus.Finance.Amount()
                   DateCreated = bogus.Date.RecentOffset 20
                   Status = Pending
-                  Type = TransactionType.Debit }
+                  Type = TransactionType.Debit
+                  ImportId = None }
 
             let! created = database.CreateAsync(user.Id, partialTransaction)
 
@@ -260,7 +268,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                   Amount = bogus.Finance.Amount()
                   DateCreated = bogus.Date.RecentOffset 5
                   Status = Cleared (bogus.Date.RecentOffset 2)
-                  Type = TransactionType.Credit }
+                  Type = TransactionType.Credit
+                  ImportId = None }
 
             // Act
             let! result = database.UpdateAsync(user.Id, created.Id, updatedTransaction)
@@ -283,7 +292,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                   Amount = bogus.Finance.Amount()
                   DateCreated = bogus.Date.RecentOffset 20
                   Status = Pending
-                  Type = TransactionType.Debit }
+                  Type = TransactionType.Debit
+                  ImportId = None }
 
             let! created = database.CreateAsync(user.Id, partialTransaction)
 
@@ -292,7 +302,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                   Amount = bogus.Finance.Amount()
                   DateCreated = bogus.Date.RecentOffset 5
                   Status = Cleared (bogus.Date.RecentOffset 2)
-                  Type = TransactionType.Credit }
+                  Type = TransactionType.Credit
+                  ImportId = None }
 
             // Act
             let! result = database.UpdateAsync(user.Id, created.Id, updatedTransaction)
@@ -311,7 +322,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                   Amount = decimal i
                   DateCreated = bogus.Date.RecentOffset 20
                   Status = Pending
-                  Type = TransactionType.Debit })
+                  Type = TransactionType.Debit
+                  ImportId = None })
 
             for transaction in transactions do
                 let! _ = database.CreateAsync(user.Id, transaction)
@@ -338,7 +350,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                   Amount = decimal i
                   DateCreated = bogus.Date.RecentOffset 20
                   Status = Pending
-                  Type = TransactionType.Debit })
+                  Type = TransactionType.Debit
+                  ImportId = None })
 
             for transaction in transactions do
                 let! _ = database.CreateAsync(user.Id, transaction)
@@ -372,7 +385,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                       Amount = decimal i
                       DateCreated = bogus.Date.RecentOffset 20
                       Status = Pending
-                      Type = TransactionType.Debit }
+                      Type = TransactionType.Debit
+                      ImportId = None }
                 let! _ = database.CreateAsync(user.Id, transaction)
                 ()
 
@@ -383,7 +397,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                       Amount = decimal i
                       DateCreated = bogus.Date.RecentOffset 20
                       Status = Cleared (bogus.Date.RecentOffset 10)
-                      Type = TransactionType.Credit }
+                      Type = TransactionType.Credit
+                      ImportId = None }
                 let! _ = database.CreateAsync(user.Id, transaction)
                 ()
 
@@ -407,7 +422,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                   Amount = bogus.Finance.Amount()
                   DateCreated = bogus.Date.RecentOffset 20
                   Status = Pending
-                  Type = TransactionType.Debit }
+                  Type = TransactionType.Debit
+                  ImportId = None }
 
             let! created = database.CreateAsync(user.Id, partialTransaction)
 
@@ -432,7 +448,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                       Amount = decimal i
                       DateCreated = bogus.Date.RecentOffset 20
                       Status = Pending
-                      Type = TransactionType.Debit }
+                      Type = TransactionType.Debit
+                      ImportId = None }
                 let! _ = database.CreateAsync(user.Id, transaction)
                 ()
 
@@ -443,7 +460,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                       Amount = decimal i
                       DateCreated = bogus.Date.RecentOffset 20
                       Status = Cleared (bogus.Date.RecentOffset 10)
-                      Type = TransactionType.Credit }
+                      Type = TransactionType.Credit
+                      ImportId = None }
                 let! _ = database.CreateAsync(user.Id, transaction)
                 ()
 
@@ -468,7 +486,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                       Amount = decimal i
                       DateCreated = bogus.Date.RecentOffset 20
                       Status = Pending
-                      Type = TransactionType.Debit }
+                      Type = TransactionType.Debit
+                      ImportId = None }
                 let! _ = database.CreateAsync(user.Id, transaction)
                 ()
 
@@ -479,7 +498,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                       Amount = decimal i
                       DateCreated = bogus.Date.RecentOffset 20
                       Status = Cleared (bogus.Date.RecentOffset 10)
-                      Type = TransactionType.Credit }
+                      Type = TransactionType.Credit
+                      ImportId = None }
                 let! _ = database.CreateAsync(user.Id, transaction)
                 ()
 
@@ -506,7 +526,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                       Amount = 100M
                       DateCreated = bogus.Date.RecentOffset 20
                       Status = Cleared (bogus.Date.RecentOffset 10)
-                      Type = TransactionType.Debit }
+                      Type = TransactionType.Debit
+                      ImportId = None }
                 let! _ = database.CreateAsync(user.Id, transaction)
                 ()
 
@@ -517,7 +538,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                       Amount = 50M
                       DateCreated = bogus.Date.RecentOffset 20
                       Status = Cleared (bogus.Date.RecentOffset 10)
-                      Type = TransactionType.Credit }
+                      Type = TransactionType.Credit
+                      ImportId = None }
                 let! _ = database.CreateAsync(user.Id, transaction)
                 ()
 
@@ -528,7 +550,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                       Amount = 75M
                       DateCreated = bogus.Date.RecentOffset 20
                       Status = Pending
-                      Type = TransactionType.Debit }
+                      Type = TransactionType.Debit
+                      ImportId = None }
                 let! _ = database.CreateAsync(user.Id, transaction)
                 ()
 
@@ -539,7 +562,8 @@ type TransactionDatabaseTests(fixture: DbContainerFixture) =
                       Amount = 25M
                       DateCreated = bogus.Date.RecentOffset 20
                       Status = Pending
-                      Type = TransactionType.Credit }
+                      Type = TransactionType.Credit
+                      ImportId = None }
                 let! _ = database.CreateAsync(user.Id, transaction)
                 ()
 

--- a/tests/FoxyBalance.Sync.Tests/CapitalOneTransactionParserTests.fs
+++ b/tests/FoxyBalance.Sync.Tests/CapitalOneTransactionParserTests.fs
@@ -1,0 +1,44 @@
+namespace FoxyBalance.Sync.Tests
+
+open System
+open FoxyBalance.Sync
+open Xunit
+open Faqt
+open Faqt.Operators
+open FoxyBalance.Sync.Models
+
+type CapitalOneTransactionParserTests() =
+    let [<Literal>] HeaderRow = """Account Number,Transaction Description,Transaction Date,Transaction Type,Transaction Amount,Balance"""
+
+    let sut = CapitalOneTransactionParser()
+
+    [<Fact>]
+    member _.``Should parse Capital One transactions``() =
+        // Setup
+        let data = $"""
+{HeaderRow}
+1122,Debit Card Purchase - MERCHANT NAME 1165 TOWN MN,11/27/25,Debit,21,405.12
+1122,Deposit from FOO B . BAZ PAY 123456,11/26/25,Credit,504.48,601.12
+"""
+
+        // Act
+        let result = sut.FromCsv data
+
+        // Assert
+        %result.Should().HaveLength 2
+        %result.Should().Be [
+            { Id = "6DYSWL"
+              DateCreated = DateTimeOffset(2025, 11, 27, 0, 0, 0, TimeSpan.Zero)
+              AccountNumber = "1122"
+              Description = "Debit Card Purchase - MERCHANT NAME 1165 TOWN MN"
+              Type = CapitalOneTransactionType.Debit
+              Amount = 21.00M
+              Balance =  405.12M }
+            { Id = "TRWHC9"
+              DateCreated = DateTimeOffset(2025, 11, 26, 0, 0, 0, TimeSpan.Zero)
+              AccountNumber = "1122"
+              Description = "Deposit from FOO B . BAZ PAY 123456"
+              Type = CapitalOneTransactionType.Credit
+              Amount = 504.48M
+              Balance =  601.12M }
+        ]

--- a/tests/FoxyBalance.Sync.Tests/FoxyBalance.Sync.Tests.fsproj
+++ b/tests/FoxyBalance.Sync.Tests/FoxyBalance.Sync.Tests.fsproj
@@ -9,6 +9,7 @@
     <UserSecretsId>33ab6fc7-395b-4f96-b66d-8b31155cd925</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CapitalOneTransactionParserTests.fs" />
     <Compile Include="Configuration.fs" />
     <Compile Include="HttpQueryTests.fs" />
     <Compile Include="GumroadClientTests.fs" />

--- a/tests/FoxyBalance.Tests.Utils/FaqtExtensions.fs
+++ b/tests/FoxyBalance.Tests.Utils/FaqtExtensions.fs
@@ -1,0 +1,48 @@
+﻿namespace Faqt
+
+open System.Runtime.CompilerServices
+open Faqt.AssertionHelpers
+
+type FaqtExtensions =
+    /// Asserts that the assertion satisfies exactly one of the items in the subject list.
+    [<Extension>]
+    static member SatisfyExactlyOneThat(t: Testable<#seq<'a>>, assertion: 'a -> 'ignored, ?because) : And<_> =
+        let stringOptimizedLength (xs: seq<'a>) =
+            match box xs with
+            | :? string as x -> x.Length
+            | _ -> Seq.length xs
+
+        use _ = t.Assert(true)
+
+        if isNull (box t.Subject) then
+            t.With("But was", t.Subject).Fail(because)
+
+        let subjectLength = stringOptimizedLength t.Subject
+
+        if subjectLength <= 0 then
+            t
+                .With("Minimum length", 1)
+                .With("Actual length", subjectLength)
+                .With("Subject value", t.Subject)
+                .Fail(because)
+
+        let failures = ResizeArray()
+        let successes = ResizeArray()
+
+        for i, a in Seq.indexed t.Subject do
+            try
+                assertion a |> ignore
+                successes.Add(box {| Index = i; Item = a |})
+            with
+            | :? AssertionFailedException as ex -> failures.Add(box ex.FailureData)
+            | ex -> failures.Add(box {| Exception = ex |})
+
+        if successes.Count <> 1 then
+            t
+                .With("Required successes", 1)
+                .With("Total successes", successes.Count)
+                .With("Successes", successes)
+                .With("Failures", failures)
+                .Fail(because)
+
+        And(t)

--- a/tests/FoxyBalance.Tests.Utils/FoxyBalance.Tests.Utils.fsproj
+++ b/tests/FoxyBalance.Tests.Utils/FoxyBalance.Tests.Utils.fsproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="FaqtExtensions.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Faqt" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This PR adds a new page where users can upload a CSV file containing their financial transactions. The uploaded spreadsheet is parsed according to the selected source format and the individual transaction records are applied to the user's balance. Currently only Capital One transaction formats are supported. A new bulk insert function was added to the transactions database that uses pgsql's COPY command to batch import all transactions to the database.

### Transaction idempotency

The import system creates a unique identifier per transaction to ensure idempotency, which will help prevent duplicate transactions from being imported if the same file is uploaded multiple times (or if the same transaction appears in multiple spreadsheets). The identifier is super simple, it's just a combination of the transaction's text that's hashed together into a CRC32 hash and then converted to base 36:

```fs
let mkTransactionId (row: CapitalOneTransactions.Row): string =
    let identifier =
        row.``Transaction Date``
        + "_" + string row.``Account Number``
        + "_" + row.``Transaction Type``
        + "_" + row.``Transaction Description``
        + "_" + string row.``Transaction Amount``
        + "_" + string row.Balance

    Encoding.UTF8.GetBytes identifier
    |> Crc32.Hash
    |> Base36Number
    |> _.ToString()
```

This creates small, unique and repeatable identifiers like so:

```
WP2XO5
-KTAQJL
61DD4U
```
